### PR TITLE
Add chalk to fix missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nestia/e2e": "^0.7.0",
     "@samchon/openapi": "^1.1.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "chalk": "^5.3.0",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^11.0.6",
     "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nestia/e2e": "^0.7.0",
     "@samchon/openapi": "^1.1.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "chalk": "^5.3.0",
+    "chalk": "^4.1.2",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^11.0.6",
     "prettier": "^3.3.3",


### PR DESCRIPTION
When I ran the `dev` script, I noticed that there were a package missing.

This pull request adds the `chalk` package as a dependency to fix a missing dependency issue.